### PR TITLE
Add support for Outbond Subject Rule String Modifiers

### DIFF
--- a/ClassExtensions/StringExtensions.cs
+++ b/ClassExtensions/StringExtensions.cs
@@ -22,5 +22,15 @@ namespace TameMyCerts.ClassExtensions
         {
             return Regex.Replace(input, from, to, RegexOptions.IgnoreCase);
         }
+
+        public static string Capitalize(this string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s;
+
+            char[] a = s.ToCharArray();
+            a[0] = char.ToUpper(a[0]);
+            return new string(a);
+        }
     }
 }


### PR DESCRIPTION
Add support for 3 string modifiers you can use in outbound subject rule values: lower: Make the value all lowercase.
upper: Make the value all uppercase.
capital Make the value Capitalized.

Usage:

{Modifier:PropertyNameGoesHere:StringModifier}

Example:
<OutboundSubjectRule>
    <Field>commonName</Field>
    <Value>{ad:sn:upper} {ad:givenName:capital}</Value>
    <Overwrite>true</Overwrite>
    <Force>true</Force>
  </OutboundSubjectRule>