### PR TITLE
Add support for Outbond Subject Rule String Modifiers

### DIFF
--- a/ClassExtensions/StringExtensions.cs
+++ b/ClassExtensions/StringExtensions.cs
@@ -22,5 +22,15 @@ namespace TameMyCerts.ClassExtensions
         {
             return Regex.Replace(input, from, to, RegexOptions.IgnoreCase);
         }
+
+        public static string Capitalize(this string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s;
+
+            char[] a = s.ToCharArray();
+            a[0] = char.ToUpper(a[0]);
+            return new string(a);
+        }
     }
 }

--- a/Validators/CertificateContentValidator.cs
+++ b/Validators/CertificateContentValidator.cs
@@ -33,19 +33,35 @@ namespace TameMyCerts.Validators
         private static string ReplaceTokenValues(string input, string identifier,
             IReadOnlyCollection<KeyValuePair<string, string>> list)
         {
+            var output = input;
+
             // This extracts all tokens and verifies if the given list contains (=knows) the token
-            foreach (Match match in new Regex(@"{" + identifier + ":([\\-a-zA-Z0-9]*?)}").Matches(input))
+            foreach (Match match in new Regex(@"{" + identifier + ":([\\-a-zA-Z0-9]*?)(:upper|:lower|:capital)?}").Matches(input))
             {
                 var token = match.Groups[1].Value;
+                var modifier = match.Groups[2].Value;
 
                 if (!list.Any(x => x.Key.Equals(token, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     throw new Exception(string.Format(LocalizedStrings.Token_invalid, token));
                 }
-            }
+                var value = list.First(x => x.Key.Equals(token, StringComparison.InvariantCultureIgnoreCase)).Value;
 
-            var output = list.Aggregate(input, (current, identity) =>
-                current.ReplaceCaseInsensitive($"{{{identifier}:{identity.Key}}}", identity.Value));
+                switch (modifier)
+                {
+                    case ":upper":
+                        value = value.ToUpper();
+                        break;
+                    case ":lower":
+                        value = value.ToLower();
+                        break;
+                    case ":capital":
+                        value = value.ToLower().Capitalize();
+                        break;
+                }
+
+                output = output.Replace($"{{{identifier}:{token}{modifier}}}", value);
+            }
 
             return output;
         }


### PR DESCRIPTION
Add support for 3 string modifiers you can use in outbound subject rule values: lower: Make the value all lowercase.
upper: Make the value all uppercase.
capital Make the value Capitalized.

Usage:

{Modifier:PropertyNameGoesHere:StringModifier}

Example:
```
<OutboundSubjectRule>
    <Field>commonName</Field>
    <Value>{ad:sn:upper} {ad:givenName:capital}</Value>
    <Overwrite>true</Overwrite>
    <Force>true</Force>
  </OutboundSubjectRule>
```