### PR TITLE
Allow max password age

### DIFF
--- a/TameMyCerts/LocalizedStrings.Designer.cs
+++ b/TameMyCerts/LocalizedStrings.Designer.cs
@@ -124,6 +124,24 @@ namespace TameMyCerts {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The password for the {0} failed to parse..
+        /// </summary>
+        internal static string DirVal_Account_Password_failed_to_parse {
+            get {
+                return ResourceManager.GetString("DirVal_Account_Password_failed_to_parse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The password is older than the allowed {0} minutes..
+        /// </summary>
+        internal static string DirVal_Account_Password_to_old {
+            get {
+                return ResourceManager.GetString("DirVal_Account_Password_to_old", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value &quot;{0}&quot; does match the expression {1} which disallowed for the object name of {2}..
         /// </summary>
         internal static string DirVal_Disallow_Match {

--- a/TameMyCerts/LocalizedStrings.resx
+++ b/TameMyCerts/LocalizedStrings.resx
@@ -268,6 +268,12 @@
   <data name="DirVal_Account_Groups_Not_Allowed" xml:space="preserve">
     <value>The {0} account for {1} is not member of any allowed group.</value>
   </data>
+  <data name="DirVal_Account_Password_failed_to_parse" xml:space="preserve">
+    <value>The password for the {0} failed to parse.</value>
+  </data>
+  <data name="DirVal_Account_Password_to_old" xml:space="preserve">
+    <value>The password is older than the allowed {0} minutes.</value>
+  </data>
   <data name="DirVal_Invalid_Directory_Attribute" xml:space="preserve">
     <value>An invalid directory attribute was specified in request policy: {0}.</value>
   </data>

--- a/TameMyCerts/Models/ActiveDirectoryObject.cs
+++ b/TameMyCerts/Models/ActiveDirectoryObject.cs
@@ -76,7 +76,14 @@ namespace TameMyCerts.Models
 
             foreach (var s in DsRetrievalAttributes.Where(s => dsObject.Properties[s].Count > 0))
             {
-                Attributes.Add(s, (string) dsObject.Properties[s][0]);
+                if (dsObject.Properties[s][0] is Int64)
+                {
+                    Attributes.Add(s, dsObject.Properties[s][0].ToString());
+                }
+                else
+                {
+                    Attributes.Add(s, (string)dsObject.Properties[s][0]);
+                }
             }
         }
 
@@ -121,7 +128,7 @@ namespace TameMyCerts.Models
             "extensionAttribute8", "extensionAttribute9", "facsimileTelephoneNumber", "gecos", "givenName", "homePhone",
             "homePostalAddress", "info", "initials", "l", "location", "mail", "mailNickname", "middleName", "mobile",
             "name", "otherMailbox", "otherMobile", "otherPager", "otherTelephone", "pager", "personalPager",
-            "personalTitle", "postalAddress", "postalCode", "postOfficeBox", "sAMAccountName", "sn", "st", "street",
+            "personalTitle", "postalAddress", "postalCode", "postOfficeBox", "pwdLastSet", "sAMAccountName", "sn", "st", "street",
             "streetAddress", "telephoneNumber", "title", "userPrincipalName"
         };
 

--- a/TameMyCerts/Models/DirectoryServicesMapping.cs
+++ b/TameMyCerts/Models/DirectoryServicesMapping.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
@@ -60,5 +61,8 @@ namespace TameMyCerts.Models
 
         [XmlElement(ElementName = "AddSidUniformResourceIdentifier")]
         public bool AddSidUniformResourceIdentifier { get; set; }
+
+        [XmlElement(ElementName = "MaximumPasswordAge")]
+        public UInt32 MaximumPasswordAge { get; set; }
     }
 }

--- a/TameMyCerts/Validators/DirectoryServiceValidator.cs
+++ b/TameMyCerts/Validators/DirectoryServiceValidator.cs
@@ -251,6 +251,32 @@ namespace TameMyCerts.Validators
 
             #endregion
 
+            #region Process Maximum password age
+            if (dsMapping.MaximumPasswordAge > 0)
+            {
+                if (!(dsObject.Attributes.ContainsKey("pwdlastset")))
+                {
+                    result.SetFailureStatus(WinError.CERTSRV_E_TEMPLATE_DENIED, string.Format(
+                        LocalizedStrings.DirVal_Account_Password_failed_to_parse, dsMapping.MaximumPasswordAge));
+                }
+                try
+                {
+                    long.TryParse(dsObject.Attributes["pwdlastSet"], out long pwdLastSetLong);
+                    UInt32 PasswordAge = (UInt32)DateTime.UtcNow.Subtract(DateTime.FromFileTimeUtc(pwdLastSetLong)).TotalMinutes;
+                    Console.WriteLine($"Password age: {PasswordAge}");
+                    if (dsMapping.MaximumPasswordAge < PasswordAge)
+                    {
+                        result.SetFailureStatus(WinError.CERTSRV_E_TEMPLATE_DENIED, string.Format(
+                        LocalizedStrings.DirVal_Account_Password_to_old, dsMapping.MaximumPasswordAge));
+                    }
+                }
+                catch
+                {
+                    result.SetFailureStatus(WinError.CERTSRV_E_TEMPLATE_DENIED, string.Format(
+    LocalizedStrings.DirVal_Account_Password_failed_to_parse, dsMapping.MaximumPasswordAge));
+                }
+            }
+            #endregion
             return result;
         }
     }


### PR DESCRIPTION
Allow restricting issuing based on max password age in minutes.
Two testcases added
Data stored as Int64 is transformed to String to allow less changes to project