### PR TITLE
.NET 8 trying to fix

### DIFF
--- a/TameMyCerts.Tests/CertificateContentValidatorTests.cs
+++ b/TameMyCerts.Tests/CertificateContentValidatorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Security.AccessControl;
 using System.Security.Principal;
 using TameMyCerts.Enums;
 using TameMyCerts.Models;
@@ -185,8 +186,8 @@ public class CertificateContentValidatorTests
 
         PrintResult(result);
 
-        Assert.True(result.CertificateProperties.Any(x =>
-            x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]) && x.Value.Equals("ADCS Labor")));
+        Assert.Contains("ADCS Labor", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization])).Select(x => x.Value));
+
     }
 
     [Fact]
@@ -236,8 +237,7 @@ public class CertificateContentValidatorTests
 
         PrintResult(result);
 
-        Assert.False(result.CertificateProperties.Any(x =>
-            x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]) && x.Value.Equals("ADCS Labor")));
+        Assert.DoesNotContain("ADCS Labor", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization])).Select(x => x.Value));
     }
 
     [Fact]
@@ -288,8 +288,7 @@ public class CertificateContentValidatorTests
 
         PrintResult(result);
 
-        Assert.True(result.CertificateProperties.Any(x =>
-            x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]) && x.Value.Equals("ADCS Labor")));
+        Assert.Contains("ADCS Labor", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization])).Select(x => x.Value));
     }
 
     [Fact]
@@ -393,9 +392,7 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]))
-            .Any(x => x.Value.Equals("intranet.adcslabor.de")));
+        Assert.Contains("intranet.adcslabor.de", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization])).Select(x => x.Value));
     }
 
     [Fact]
@@ -431,12 +428,19 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.CommonName]) &&
-                    result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.CommonName]]
-                        .Equals(string.Empty));
-        Assert.True(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.Organization]) &&
-                    result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.Organization]]
-                        .Equals("intranet.adcslabor.de"));
+
+        Assert.Multiple(() =>
+            {
+                Assert.Contains(RdnTypes.NameProperty[RdnTypes.CommonName], result.CertificateProperties.Keys.ToList());
+                Assert.Empty(result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.CommonName]]);
+            }
+        );
+        Assert.Multiple(() =>
+            {
+                Assert.Contains(RdnTypes.NameProperty[RdnTypes.Organization], result.CertificateProperties.Keys.ToList());
+                Assert.Equal("intranet.adcslabor.de", result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.Organization]]);
+            }
+        );
     }
 
     [Fact]
@@ -465,10 +469,12 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(
-            result.CertificateExtensions.ContainsKey(WinCrypt.szOID_SUBJECT_ALT_NAME2) &&
-            Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2])
-                .Equals("MBeCFWludHJhbmV0LmFkY3NsYWJvci5kZQ=="));
+        Assert.Multiple(() =>
+        {
+            Assert.Contains(WinCrypt.szOID_SUBJECT_ALT_NAME2, result.CertificateExtensions.Keys.ToList());
+            Assert.Equal("MBeCFWludHJhbmV0LmFkY3NsYWJvci5kZQ==", Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2]));
+        }
+       );
     }
 
     [Fact]
@@ -498,9 +504,7 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]))
-            .Any(x => x.Value.Equals("intranet.adcslabor.de")));
+        Assert.Contains("intranet.adcslabor.de", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization])).Select(x => x.Value));
     }
 
     [Fact]
@@ -560,9 +564,7 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("test")));
+        Assert.Contains("test", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]
@@ -649,9 +651,7 @@ public class CertificateContentValidatorTests
 
         Assert.False(result.DeniedForIssuance);
         Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("intranet.adcslabor.de")));
+        Assert.Contains("intranet.adcslabor.de", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]
@@ -858,10 +858,13 @@ public class CertificateContentValidatorTests
 
         PrintResult(result);
 
-        Assert.True(
-            result.CertificateExtensions.ContainsKey(WinCrypt.szOID_SUBJECT_ALT_NAME2) &&
-            Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2])
-                .Equals(expectedResult));
+        Assert.Multiple(() =>
+            {
+                Assert.Contains(WinCrypt.szOID_SUBJECT_ALT_NAME2, result.CertificateExtensions.Keys.ToList());
+                Assert.Equal(expectedResult, Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2]));
+            }
+        );
+
     }
 
 
@@ -943,10 +946,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("rudi@intra.adcslabor.de"))
-        );
+        Assert.Contains("rudi@intra.adcslabor.de", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]
@@ -975,10 +975,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("rudi@intra.adcslabor.de"))
-        );
+        Assert.Contains("rudi@intra.adcslabor.de", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]
@@ -1065,10 +1062,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("Ratlos, Rudi"))
-        );
+        Assert.Contains("Ratlos, Rudi", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]
@@ -1097,10 +1091,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.CertificateProperties
-            .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
-            .Any(x => x.Value.Equals("Rudi is Rudi"))
-        );
+        Assert.Contains("Rudi is Rudi", result.CertificateProperties.Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName])).Select(x => x.Value));
     }
 
     [Fact]

--- a/TameMyCerts.Tests/CertificateContentValidatorTests.cs
+++ b/TameMyCerts.Tests/CertificateContentValidatorTests.cs
@@ -307,7 +307,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.NTE_FAIL));
+        Assert.Equal(WinError.NTE_FAIL, result.StatusCode);
     }
 
     [Fact]
@@ -335,7 +335,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERTSRV_E_TEMPLATE_DENIED));
+        Assert.Equal(WinError.CERTSRV_E_TEMPLATE_DENIED, result.StatusCode);
     }
 
 
@@ -364,7 +364,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties
             .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]))
             .Any(x => x.Value.Equals("intranet.adcslabor.de")));
@@ -430,7 +430,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.CommonName]) &&
                     result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.CommonName]]
                         .Equals(string.Empty));
@@ -464,7 +464,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(
             result.CertificateExtensions.ContainsKey(WinCrypt.szOID_SUBJECT_ALT_NAME2) &&
             Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2])
@@ -497,7 +497,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties
             .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.Organization]))
             .Any(x => x.Value.Equals("intranet.adcslabor.de")));
@@ -559,7 +559,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties
             .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
             .Any(x => x.Value.Equals("test")));
@@ -591,7 +591,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(
             result.CertificateExtensions.ContainsKey(WinCrypt.szOID_SUBJECT_ALT_NAME2) &&
             Convert.ToBase64String(result.CertificateExtensions[WinCrypt.szOID_SUBJECT_ALT_NAME2])
@@ -648,7 +648,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties
             .Where(x => x.Key.Equals(RdnTypes.NameProperty[RdnTypes.CommonName]))
             .Any(x => x.Value.Equals("intranet.adcslabor.de")));
@@ -679,7 +679,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERTSRV_E_TEMPLATE_DENIED));
+        Assert.Equal(WinError.CERTSRV_E_TEMPLATE_DENIED, result.StatusCode);
     }
 
     [Fact]
@@ -1007,8 +1007,8 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERTSRV_E_TEMPLATE_DENIED));
-        Assert.True(string.Join("\n", result.Description.ToList()).Contains("test-attribute"));
+        Assert.Equal(WinError.CERTSRV_E_TEMPLATE_DENIED, result.StatusCode);
+        Assert.Contains("test-attribute", string.Join("\n", result.Description.ToList()));
     }
 
     [Fact]
@@ -1321,7 +1321,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.CommonName]) &&
                     result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.CommonName]]
                         .Equals(string.Empty));
@@ -1351,7 +1351,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.True(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.State]) &&
                     result.CertificateProperties[RdnTypes.NameProperty[RdnTypes.State]].Equals(string.Empty));
     }
@@ -1380,7 +1380,7 @@ public class CertificateContentValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
         Assert.False(result.CertificateProperties.ContainsKey(RdnTypes.NameProperty[RdnTypes.CommonName]));
     }
 

--- a/TameMyCerts.Tests/CertificateRequestValidatorTests.cs
+++ b/TameMyCerts.Tests/CertificateRequestValidatorTests.cs
@@ -271,7 +271,7 @@ public class CertificateRequestValidatorTests
 
         Assert.True(result.DeniedForIssuance);
         Assert.True(result.StatusCode.Equals(WinError.CERTSRV_E_KEY_LENGTH));
-        Assert.True(string.Join(";", result.Description).Contains("ECC"));
+        Assert.Contains("ECC", string.Join(";", result.Description));
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public class CertificateRequestValidatorTests
 
         Assert.True(result.DeniedForIssuance);
         Assert.True(result.StatusCode.Equals(WinError.CERTSRV_E_KEY_LENGTH));
-        Assert.True(string.Join(";", result.Description).Contains("DSA"));
+        Assert.Contains("DSA", string.Join(";", result.Description));
     }
 
     [Fact]
@@ -2113,26 +2113,26 @@ public class CertificateRequestValidatorTests
 
         Assert.True(result.DeniedForIssuance);
         Assert.True(result.StatusCode.Equals(WinError.CERT_E_INVALID_NAME));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.CommonName)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Country)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Email)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.DomainComponent)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Locality)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Organization)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.OrgUnit)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.State)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.GivenName)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Initials)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.SurName)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.StreetAddress)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.Title)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.UnstructuredName)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.UnstructuredAddress)));
-        Assert.True(identities.Any(x => x.Key.Equals(RdnTypes.DeviceSerialNumber)));
-        Assert.True(identities.Any(x => x.Key.Equals("postalCode")));
-        Assert.True(identities.Any(x => x.Key.Equals("postOfficeBox")));
-        Assert.True(identities.Any(x => x.Key.Equals("telephoneNumber")));
-        Assert.True(identities.Any(x => x.Key.Equals("description")));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.CommonName));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Country));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Email));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.DomainComponent));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Locality));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Organization));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.OrgUnit));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.State));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.GivenName));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Initials));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.SurName));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.StreetAddress));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.Title));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.UnstructuredName));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.UnstructuredAddress));
+        Assert.Contains(identities, x => x.Key.Equals(RdnTypes.DeviceSerialNumber));
+        Assert.Contains(identities, x => x.Key.Equals("postalCode"));
+        Assert.Contains(identities, x => x.Key.Equals("postOfficeBox"));
+        Assert.Contains(identities, x => x.Key.Equals("telephoneNumber"));
+        Assert.Contains(identities, x => x.Key.Equals("description"));
     }
 
     [Fact]
@@ -2226,7 +2226,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERT_E_INVALID_NAME));
+        Assert.Equal(WinError.CERT_E_INVALID_NAME, result.StatusCode);
     }
 
     [Fact]
@@ -2281,7 +2281,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERT_E_INVALID_NAME));
+        Assert.Equal(WinError.CERT_E_INVALID_NAME, result.StatusCode);
     }
 
     [Fact]
@@ -2312,7 +2312,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERT_E_INVALID_NAME));
+        Assert.Equal(WinError.CERT_E_INVALID_NAME, result.StatusCode);
     }
 
     [Fact]
@@ -2345,7 +2345,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.CERT_E_INVALID_NAME));
+        Assert.Equal(WinError.CERT_E_INVALID_NAME, result.StatusCode);
     }
 
     [Fact]
@@ -2365,7 +2365,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_SUCCESS));
+        Assert.Equal(WinError.ERROR_SUCCESS, result.StatusCode);
 
         Assert.True(result.NotAfter.Equals(DateTimeOffset.ParseExact(notAfter, "o",
             CultureInfo.InvariantCulture.DateTimeFormat,
@@ -2387,6 +2387,6 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.True(result.DeniedForIssuance);
-        Assert.True(result.StatusCode.Equals(WinError.ERROR_INVALID_TIME));
+        Assert.Equal(WinError.ERROR_INVALID_TIME, result.StatusCode);
     }
 }

--- a/TameMyCerts.Tests/CertificateRequestValidatorTests.cs
+++ b/TameMyCerts.Tests/CertificateRequestValidatorTests.cs
@@ -2058,7 +2058,7 @@ public class CertificateRequestValidatorTests
         PrintResult(result);
 
         Assert.False(result.DeniedForIssuance);
-        Assert.True(result.DisabledCertificateExtensions.Contains(WinCrypt.szOID_NTDS_CA_SECURITY_EXT));
+        Assert.Contains(WinCrypt.szOID_NTDS_CA_SECURITY_EXT, result.DisabledCertificateExtensions);
     }
 
     [Fact]

--- a/TameMyCerts.Tests/TameMyCerts.Tests.csproj
+++ b/TameMyCerts.Tests/TameMyCerts.Tests.csproj
@@ -8,6 +8,12 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA1416</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;CA1416</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TameMyCerts\TameMyCerts.csproj" />
   </ItemGroup>

--- a/TameMyCerts.Tests/X509CertificateExtensionAuthorityInformationAccessTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionAuthorityInformationAccessTests.cs
@@ -29,7 +29,7 @@ public class X509CertificateExtensionAuthorityInformationAccessTests
 
         aiaExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(aiaExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(aiaExt.RawData));
     }
 
     [Fact]
@@ -44,6 +44,6 @@ public class X509CertificateExtensionAuthorityInformationAccessTests
         aiaExt.AddUniformResourceIdentifier("http://pki.tamemycerts-tests.local/CertData/TEST-CA.crt");
         aiaExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(aiaExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(aiaExt.RawData));
     }
 }

--- a/TameMyCerts.Tests/X509CertificateExtensionAuthorityKeyIdentifierTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionAuthorityKeyIdentifierTests.cs
@@ -19,6 +19,6 @@ public class X509CertificateExtensionAuthorityKeyIdentifierTests
 
         var akiExt = new X509CertificateExtensionAuthorityKeyIdentifier(akiBytes);
 
-        Assert.True(Convert.ToBase64String(akiExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(akiExt.RawData));
     }
 }

--- a/TameMyCerts.Tests/X509CertificateExtensionCrlDistributionPointTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionCrlDistributionPointTests.cs
@@ -28,7 +28,7 @@ public class X509CertificateExtensionCrlDistributionPointTests
 
         cdpExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(cdpExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(cdpExt.RawData));
     }
 
     [Fact]
@@ -43,6 +43,6 @@ public class X509CertificateExtensionCrlDistributionPointTests
         cdpExt.AddUniformResourceIdentifier("http://pki.tamemycerts-tests.local/CertData/TEST-CA.crl");
         cdpExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(cdpExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(cdpExt.RawData));
     }
 }

--- a/TameMyCerts.Tests/X509CertificateExtensionOcspMustStapleTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionOcspMustStapleTests.cs
@@ -13,6 +13,6 @@ public class X509CertificateExtensionOcspMustStapleTests
 
         var ocspStaplingExt = new X509CertificateExtensionOcspMustStaple();
 
-        Assert.True(Convert.ToBase64String(ocspStaplingExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(ocspStaplingExt.RawData));
     }
 }

--- a/TameMyCerts.Tests/X509CertificateExtensionSecurityIdentifierTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionSecurityIdentifierTests.cs
@@ -18,6 +18,6 @@ public class X509CertificateExtensionSecurityIdentifierTests
 
         var sidExt = new X509CertificateExtensionSecurityIdentifier(new SecurityIdentifier(sid));
 
-        Assert.True(Convert.ToBase64String(sidExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sidExt.RawData));
     }
 }

--- a/TameMyCerts.Tests/X509CertificateExtensionSubjectAlternativeNameTests.cs
+++ b/TameMyCerts.Tests/X509CertificateExtensionSubjectAlternativeNameTests.cs
@@ -30,8 +30,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         var sanExt = new X509CertificateExtensionSubjectAlternativeName();
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
-        Assert.True(sanExt.AlternativeNames.Count.Equals(0));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
+        Assert.Empty(sanExt.AlternativeNames);
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         var sanExt = new X509CertificateExtensionSubjectAlternativeName(string.Empty);
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
-        Assert.True(sanExt.AlternativeNames.Count.Equals(0));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
+        Assert.Empty(sanExt.AlternativeNames);
     }
 
     [Fact]
@@ -50,8 +50,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         var sanExt = new X509CertificateExtensionSubjectAlternativeName(Array.Empty<byte>());
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
-        Assert.True(sanExt.AlternativeNames.Count.Equals(0));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
+        Assert.Empty(sanExt.AlternativeNames);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
             "tag:microsoft.com,2022-09-14:sid:S-1-5-21-1381186052-4247692386-135928078-1225");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddDnsName("some-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddIpAddress(IPAddress.Parse("192.168.0.1"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddUserPrincipalName("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddEmailAddress(new MailAddress("Administrator@tamemycerts-tests.local"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddEmailAddress("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddUniformResourceIdentifier(new Uri("http://some-test.tamemycerts-tests.local/"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddUniformResourceIdentifier("http://some-test.tamemycerts-tests.local/");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveDnsName("some-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -185,8 +185,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         var sanExt = new X509CertificateExtensionSubjectAlternativeName(rawData);
 
-        Assert.True(sanExt.AlternativeNames[0].Key == SanTypes.IpAddress);
-        Assert.True(sanExt.AlternativeNames[0].Value == "192.168.0.1");
+        Assert.Equal(SanTypes.IpAddress, sanExt.AlternativeNames[0].Key);
+        Assert.Equal("192.168.0.1", sanExt.AlternativeNames[0].Value);
     }
 
     [Fact]
@@ -196,8 +196,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         var sanExt = new X509CertificateExtensionSubjectAlternativeName(rawData);
 
-        Assert.True(sanExt.AlternativeNames[0].Key == SanTypes.UserPrincipalName);
-        Assert.True(sanExt.AlternativeNames[0].Value == "Administrator@tamemycerts-tests.local");
+        Assert.Equal(SanTypes.UserPrincipalName, sanExt.AlternativeNames[0].Key);
+        Assert.Equal("Administrator@tamemycerts-tests.local", sanExt.AlternativeNames[0].Value);
     }
 
     [Fact]
@@ -218,8 +218,8 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         var sanExt = new X509CertificateExtensionSubjectAlternativeName(rawData);
 
-        Assert.True(sanExt.AlternativeNames[0].Key == SanTypes.UniformResourceIdentifier);
-        Assert.True(sanExt.AlternativeNames[0].Value == "http://some-test.tamemycerts-tests.local/");
+        Assert.Equal(SanTypes.UniformResourceIdentifier, sanExt.AlternativeNames[0].Key);
+        Assert.Equal("http://some-test.tamemycerts-tests.local/", sanExt.AlternativeNames[0].Value);
     }
 
     [Fact]
@@ -232,7 +232,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddDnsName("some-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -242,7 +242,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName("thisisnotvalid", "some-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName(SanTypes.DnsName, "thisisnotvalid!?");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName(SanTypes.IpAddress, "thisisnotvalid!?");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName(SanTypes.UserPrincipalName, "thisisnotvalid!?");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName(SanTypes.Rfc822Name, "thisisnotvalid!?");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -292,7 +292,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddAlternativeName(SanTypes.UniformResourceIdentifier, "thisisnotvalid!?");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<byte>(), sanExt.RawData);
     }
 
     [Fact]
@@ -305,7 +305,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddIpAddress(IPAddress.Parse("192.168.0.1"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -319,7 +319,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddUserPrincipalName("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -332,7 +332,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddEmailAddress(new MailAddress("Administrator@tamemycerts-tests.local"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddUniformResourceIdentifier(new Uri("http://some-test.tamemycerts-tests.local/"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -359,7 +359,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddDnsName("another-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -375,7 +375,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         Console.WriteLine(Convert.ToBase64String(sanExt.RawData));
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -391,7 +391,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         Console.WriteLine(Convert.ToBase64String(sanExt.RawData));
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -407,7 +407,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
 
         Console.WriteLine(Convert.ToBase64String(sanExt.RawData));
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -420,7 +420,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.AddIpAddress(IPAddress.Parse("192.168.0.1"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -434,7 +434,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveDnsName("another-test.tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -447,7 +447,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveIpAddress(IPAddress.Parse("192.168.0.1"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -461,7 +461,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveUniformResourceIdentifier(new Uri("http://some-test.tamemycerts-tests.local/"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -475,7 +475,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveUniformResourceIdentifier("http://some-test.tamemycerts-tests.local/");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -489,7 +489,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveEmailAddress(new MailAddress("Administrator@tamemycerts-tests.local"));
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -503,7 +503,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveEmailAddress("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -517,7 +517,7 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveUserPrincipalName("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(Convert.ToBase64String(sanExt.RawData).Equals(expectedResult));
+        Assert.Equal(expectedResult, Convert.ToBase64String(sanExt.RawData));
     }
 
     [Fact]
@@ -527,6 +527,6 @@ public class X509CertificateExtensionSubjectAlternativeNameTests
         sanExt.RemoveUserPrincipalName("Administrator@tamemycerts-tests.local");
         sanExt.InitializeEncode();
 
-        Assert.True(sanExt.RawData.Equals(Array.Empty<byte>()));
+        Assert.Equal(Array.Empty<Byte>(), sanExt.RawData);
     }
 }

--- a/TameMyCerts/TameMyCerts.csproj
+++ b/TameMyCerts/TameMyCerts.csproj
@@ -12,9 +12,15 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>true</Optimize>
+    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
 	<PropertyGroup>
 		<EnableComHosting>true</EnableComHosting>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/Sleepw4lker/TameMyCerts.git</RepositoryUrl>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	  <NoWarn>1701;1702;CA1416</NoWarn>
 	</PropertyGroup>
   <ItemGroup>
     <Compile Update="AutoVersionIncrement.cs">


### PR DESCRIPTION
I have added CA1416 to the ignore list, this warns about that parts of TMC code dont work outside Windows machines.

I tried to remove all of these errors:
A violation of this rule occurs when Assert.True or Assert.False are used with string.Equals to check if two strings are equal.
https://xunit.net/xunit.analyzers/rules/xUnit2010

A violation of this rule occurs when Enumerable.Any is used to check if a value matching a predicate exists in a collection.
https://xunit.net/xunit.analyzers/rules/xUnit2012